### PR TITLE
feat(cli): implement cwm status command

### DIFF
--- a/comply_with_me/downloaders/__init__.py
+++ b/comply_with_me/downloaders/__init__.py
@@ -18,14 +18,15 @@ class ServiceDef:
     key: str
     label: str
     runner: Callable[[Path, bool, bool, Optional["StateFile"]], DownloadResult]
+    subdir: str  # path prefix under output_dir used by this downloader
 
 
 SERVICES: list[ServiceDef] = [
-    ServiceDef("fedramp", "FedRAMP", fedramp.run),
-    ServiceDef("nist-finals", "NIST Final Publications", nist.run_finals),
-    ServiceDef("nist-drafts", "NIST Draft Publications", nist.run_drafts),
-    ServiceDef("cmmc", "CMMC", cmmc.run),
-    ServiceDef("disa", "DISA STIGs", disa.run),
+    ServiceDef("fedramp", "FedRAMP", fedramp.run, "fedramp"),
+    ServiceDef("nist-finals", "NIST Final Publications", nist.run_finals, "nist/final-pubs"),
+    ServiceDef("nist-drafts", "NIST Draft Publications", nist.run_drafts, "nist/draft-pubs"),
+    ServiceDef("cmmc", "CMMC", cmmc.run, "cmmc"),
+    ServiceDef("disa", "DISA STIGs", disa.run, "disa-stigs"),
 ]
 
 SERVICES_BY_KEY: dict[str, ServiceDef] = {s.key: s for s in SERVICES}


### PR DESCRIPTION
## Summary

- Replaces the `cwm status` stub with a working implementation backed by the state file from #9
- Adds `subdir` field to `ServiceDef` so each service declares its output path prefix

## Behavior

**`cwm status`** — summary table across all frameworks:
```
────────────── cwm status ──────────────
Framework                  Files    Size    Last Synced
FedRAMP                        2  3.4 MB    2026-02-25 14:31 UTC
NIST Final Publications        1  5.0 MB    2026-02-24 09:15 UTC
NIST Draft Publications        1  3.0 MB    2026-02-24 09:22 UTC
CMMC                          --      --    never
DISA STIGs                     1  4.2 GB    2026-02-24 10:01 UTC
────────────────────────────────────────
Total: 5 files  4.2 GB  across 4 framework(s)
```

**`cwm status fedramp`** — per-file detail for one framework:
```
──────────────── FedRAMP ────────────────
File                           Size    Last Synced
FedRAMP_rev5_SSP_Template.docx  1.1 MB  2026-02-25 14:31 UTC
FedRAMP_rev5_catalog.pdf        2.3 MB  2026-02-25 14:30 UTC
─────────────────────────────────────────
2 files  3.4 MB
```

- Frameworks with no synced files show a "never" row in summary / "run cwm sync" message in detail
- No state file → "No sync history found. Run cwm sync to get started."

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)