### PR TITLE
feat(downloaders): CMMC curated URL fallback with verification timestamp

### DIFF
--- a/comply_with_me/cli.py
+++ b/comply_with_me/cli.py
@@ -59,6 +59,10 @@ def _print_result(result: DownloadResult, dry_run: bool) -> None:
             f"[bold]source-content/{result.framework}/[/bold] when done."
         )
 
+    if result.notices:
+        for notice in result.notices:
+            _console.print(f"  [dim cyan]note: {notice}[/dim cyan]")
+
     if not any([result.downloaded, result.skipped, result.errors, result.manual_required]):
         _console.print("  [dim]Nothing to do.[/dim]")
 

--- a/comply_with_me/downloaders/base.py
+++ b/comply_with_me/downloaders/base.py
@@ -31,6 +31,7 @@ class DownloadResult:
     skipped: list[str] = field(default_factory=list)
     errors: list[tuple[str, str]] = field(default_factory=list)
     manual_required: list[tuple[str, str]] = field(default_factory=list)
+    notices: list[str] = field(default_factory=list)
 
     @property
     def total(self) -> int:


### PR DESCRIPTION
## Summary

- Adds `KNOWN_URLS` (20 docs) and `KNOWN_URLS_VERIFIED = "2026-02-25"` to `cmmc.py` — a curated fallback for when the DoD resources page is WAF-blocked
- `_try_scrape()` consolidates plain-requests + Playwright attempts; returns parsed links or `None`
- `_links_from_known_urls()` converts `KNOWN_URLS` to standard tuple format with `unquote()` for percent-encoded filenames
- Removes dead `_playwright_download()` — the HTML page is always blocked so Playwright download was unreachable
- `run()` uses `_try_scrape() or _links_from_known_urls()` → `_requests_download()` for all cases
- `DownloadResult` gets a `notices: list[str]` field (in `base.py`)
- `_print_result()` in `cli.py` surfaces notices so users see the timestamp warning whenever the fallback is used

## What it looks like

```
  note: URL list last verified 2026-02-25. Check
https://dodcio.defense.gov/cmmc/Resources-Documentation/ for new documents.
```

## Updating the list

When DoD publishes new documents, update `KNOWN_URLS` in `cmmc.py` and bump `KNOWN_URLS_VERIFIED` to the date you verified it.

## Test plan

- [ ] `cwm sync cmmc --dry-run` — exit 0, 20 would-download, notice fires with date
- [ ] `ruff check comply_with_me/` passes
- [ ] If scraping ever succeeds (WAF lifted), notice does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)