### PR TITLE
fix(cli): improve CMMC fallback notice and notice rendering (#26)

### DIFF
--- a/comply_with_me/cli.py
+++ b/comply_with_me/cli.py
@@ -27,8 +27,8 @@ def _check_dependencies() -> None:
         for pkg in missing_pkgs:
             print(f"  - {pkg}")
         print()
-        print("Run the tool via cwm.py to install automatically:")
-        print("  python3 cwm.py")
+        print("Run the tool via comply_with_me.py to install automatically:")
+        print("  python3 comply_with_me.py")
         print()
         sys.exit(1)
 
@@ -91,8 +91,9 @@ def _run_sync(svc, output_dir: Path, state) -> None:
                 print(f"    {label}")
                 print(f"    {url}")
         if result.notices:
+            print()
             for notice in result.notices:
-                print(f"  Note: {notice}")
+                print(f"  [!] {notice}")
     except Exception as exc:  # noqa: BLE001
         print(f" failed.\n  Error: {exc}")
 

--- a/comply_with_me/downloaders/cmmc.py
+++ b/comply_with_me/downloaders/cmmc.py
@@ -240,8 +240,9 @@ def run(
                 result.downloaded.append(filename)
         if used_known_urls:
             result.notices.append(
-                f"URL list last verified {KNOWN_URLS_VERIFIED}. "
-                f"Check {SOURCE_URL} for new documents."
+                f"Automated download unavailable — DoD portal blocked access. "
+                f"Used last-known-good URL list (last verified {KNOWN_URLS_VERIFIED}). "
+                f"See comply_with_me/downloaders/cmmc.py (KNOWN_URLS) for the full URL list."
             )
         return result
 
@@ -249,7 +250,8 @@ def run(
     result = _requests_download(links, dest, force, state)
     if used_known_urls:
         result.notices.append(
-            f"URL list last verified {KNOWN_URLS_VERIFIED} — "
-            f"check {SOURCE_URL} for new documents."
+            f"Automated download unavailable — DoD portal blocked access. "
+            f"Used last-known-good URL list (last verified {KNOWN_URLS_VERIFIED}). "
+            f"See comply_with_me/downloaders/cmmc.py (KNOWN_URLS) for the full URL list."
         )
     return result


### PR DESCRIPTION
## Summary

- **`cmmc.py`** — replaced the vague "URL list last verified" notice with an explicit three-part message:
  1. States that automated download was unavailable due to DoD portal access restrictions
  2. Confirms the fallback to the last-known-good URL list and its verification date
  3. Directs the user to `comply_with_me/downloaders/cmmc.py` (`KNOWN_URLS`) for the full URL list
- **`cli.py`** — notices now render with a `[!]` prefix and a blank line separator so they stand out visually from the sync summary lines above
- **`cli.py`** — fixed stale `python3 cwm.py` reference in the dependency error message → `comply_with_me.py`

### Before / After

**Before:**
```
  Note: URL list last verified 2026-02-25 — check https://dodcio.defense.gov/... for new documents.
```

**After:**
```
  [!] Automated download unavailable — DoD portal blocked access. Used last-known-good URL list (last verified 2026-02-25). See comply_with_me/downloaders/cmmc.py (KNOWN_URLS) for the full URL list.
```

Closes #26

## Test plan

- [ ] Trigger CMMC sync when live scrape fails — confirm `[!]` notice appears with full message
- [ ] Trigger CMMC sync when live scrape succeeds — confirm no notice is shown
- [ ] `ruff check comply_with_me/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)