### PR TITLE
fix: normalize progress prints once per framework (#28)

### DIFF
--- a/comply_with_me/cli.py
+++ b/comply_with_me/cli.py
@@ -106,14 +106,11 @@ def _run_normalize(source_dir: Path, output_dir: Path) -> None:
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Track counts per framework for the summary line
-    counts: dict[str, dict] = {}
+    seen_frameworks: set[str] = set()
 
     def _progress(framework_key: str, filename: str) -> None:
-        if framework_key not in counts:
-            counts[framework_key] = {"processed": 0, "skipped": 0, "errors": 0, "unsupported": 0}
-        # Print a rolling framework header the first time we see a new framework
-        if counts[framework_key]["processed"] + counts[framework_key]["skipped"] == 0:
+        if framework_key not in seen_frameworks:
+            seen_frameworks.add(framework_key)
             print(f"  Normalizing {framework_key}...", flush=True)
 
     print("Normalizing downloaded documents...")


### PR DESCRIPTION
## Bug fixed (caught in test run)

`_run_normalize()` in `cli.py` tracked a `counts` dict that was initialized but never incremented inside the callback (the callback fires *before* the file is processed). The "first time" check `processed + skipped == 0` was therefore always true, causing the framework header to print once per file instead of once per framework.

**Before:**
```
  Normalizing fedramp...
  Normalizing fedramp...
  Normalizing fedramp...
  ... (×36)
```
**After:**
```
  Normalizing fedramp...
  Normalizing cmmc...
```

Fix: replaced the broken counter dict with a simple `seen_frameworks: set[str]`.

## Separate issue noted (not fixed here)

Most KNOWN_URLS from `dodcio.defense.gov` are landing in `manual_required`, suggesting the DoD portal may now block direct PDF downloads as well as the index page. Worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)