### PR TITLE
fix(bootstrap): show packages to be installed before prompting

### DIFF
--- a/comply_with_me.py
+++ b/comply_with_me.py
@@ -66,8 +66,10 @@ def _bootstrap() -> None:
             print("\nThen run the script again.")
             sys.exit(1)
 
+        pkg_list = ", ".join(pkg for pkg, _ in REQUIRED)
         print("Comply With Me needs a local environment to run.\n")
-        print(f"It will be created at: {VENV_DIR}\n")
+        print(f"It will be created at: {VENV_DIR}")
+        print(f"Packages to install  : {pkg_list}\n")
         try:
             answer = input("Set it up now? [y/N] ").strip().lower()
         except (KeyboardInterrupt, EOFError):


### PR DESCRIPTION
## Change

Adds a "Packages to install" line to the bootstrap prompt so the user knows exactly what will be installed before answering y/N.

**Before:**
```
Comply With Me needs a local environment to run.

It will be created at: /path/to/.cwm-venv

Set it up now? [y/N]
```

**After:**
```
Comply With Me needs a local environment to run.

It will be created at: /path/to/.cwm-venv
Packages to install  : requests, beautifulsoup4, pymupdf

Set it up now? [y/N]
```

The list is derived from the `REQUIRED` constant, so it stays in sync automatically if packages are added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)