### PR TITLE
fix(downloaders): add WAF fallback to CISA BOD downloader

### DIFF
--- a/cwm/downloaders/cisa_bod.py
+++ b/cwm/downloaders/cisa_bod.py
@@ -3,10 +3,11 @@
 CISA BODs are published as HTML pages, not PDFs — the full directive text is
 embedded in each detail page at cisa.gov/news-events/directives/bod-*.
 
-Fetch strategy:
-1. Scrape the index page (SOURCE_URL) for all BOD detail-page links
-2. Download each detail page as a .html file into source-content/cisa-bod/
-   using the URL slug as the filename (e.g. bod-25-01-...html)
+Fetch strategy (index page, in order):
+1. Plain requests.get() — fast, works if CISA's WAF allows it
+2. Playwright headless browser — fallback if plain request is blocked
+3. Curated KNOWN_URLS list — last resort if the index itself cannot be scraped;
+   individual BOD pages are still publicly accessible even when the index is blocked
 """
 
 from __future__ import annotations
@@ -28,6 +29,7 @@ from .base import (
     USER_AGENT,
     DownloadResult,
     download_file,
+    require_playwright,
     sanitize_filename,
 )
 
@@ -37,15 +39,47 @@ BASE_URL = "https://www.cisa.gov"
 # URL path prefix that all BOD detail pages share
 BOD_PATH_PREFIX = "/news-events/directives/bod-"
 
+# ---------------------------------------------------------------------------
+# Curated fallback URL list
+# ---------------------------------------------------------------------------
 
-def _fetch_html(url: str) -> Optional[str]:
-    """Fetch a page via plain requests. Returns response text or None on failure."""
-    headers = {"User-Agent": USER_AGENT}
+# Date these URLs were last manually verified against SOURCE_URL.
+KNOWN_URLS_VERIFIED = "2026-02-26"
+
+# Direct BOD detail page URLs. Used when the index page cannot be scraped.
+KNOWN_URLS: list[str] = [
+    "https://www.cisa.gov/news-events/directives/bod-26-02-mitigating-risk-end-support-edge-devices",
+    "https://www.cisa.gov/news-events/directives/bod-25-01-implementing-secure-practices-cloud-services",
+    "https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services",
+    "https://www.cisa.gov/news-events/directives/binding-operational-directive-23-02",
+    "https://www.cisa.gov/news-events/directives/bod-23-02-implementation-guidance-mitigating-risk-internet-exposed-management-interfaces",
+    "https://www.cisa.gov/news-events/directives/bod-23-01-improving-asset-visibility-and-vulnerability-detection-federal-networks",
+    "https://www.cisa.gov/news-events/directives/bod-23-01-implementation-guidance-improving-asset-visibility-and-vulnerability-detection-federal",
+    "https://www.cisa.gov/news-events/directives/bod-22-01-reducing-significant-risk-known-exploited-vulnerabilities",
+    "https://www.cisa.gov/news-events/directives/bod-20-01-develop-and-publish-vulnerability-disclosure-policy",
+    "https://www.cisa.gov/news-events/directives/bod-19-02-vulnerability-remediation-requirements-internet-accessible-systems",
+    "https://www.cisa.gov/news-events/directives/bod-18-02-securing-high-value-assets",
+    "https://www.cisa.gov/news-events/directives/bod-18-01-enhance-email-and-web-security",
+    "https://www.cisa.gov/news-events/directives/bod-17-01-removal-kaspersky-branded-products",
+    "https://www.cisa.gov/news-events/directives/bod-16-03-2016-agency-cybersecurity-reporting-requirements",
+    "https://www.cisa.gov/news-events/directives/bod-16-02-threat-network-infrastructure-devices",
+    "https://www.cisa.gov/news-events/directives/binding-operational-directive-16-01",
+    "https://www.cisa.gov/news-events/directives/binding-operational-directive-15-01",
+]
+
+# ---------------------------------------------------------------------------
+# Index page fetching
+# ---------------------------------------------------------------------------
+
+
+def _fetch_html_plain() -> Optional[str]:
+    """Fetch the index page via plain requests. Returns HTML or None."""
     import time
 
+    headers = {"User-Agent": USER_AGENT}
     for attempt in range(REQUEST_RETRIES):
         try:
-            resp = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+            resp = requests.get(SOURCE_URL, headers=headers, timeout=REQUEST_TIMEOUT)
             if resp.status_code == 200:
                 return resp.text
         except requests.RequestException:
@@ -55,12 +89,25 @@ def _fetch_html(url: str) -> Optional[str]:
     return None
 
 
-def _parse_bod_links(html: str) -> list[tuple[str, str]]:
-    """Return list of (filename, full_url) for all BOD detail pages on the index.
+def _fetch_html_playwright() -> Optional[str]:
+    """Fetch the index page via Playwright headless browser. Returns HTML or None."""
+    try:
+        require_playwright()
+        from playwright.sync_api import sync_playwright
 
-    Filters for links whose path starts with BOD_PATH_PREFIX to capture both
-    main directive pages and implementation-guidance pages.
-    """
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+            page = browser.new_page(user_agent=USER_AGENT)
+            page.goto(SOURCE_URL, wait_until="networkidle")
+            html = page.content()
+            browser.close()
+        return html
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _parse_bod_links(html: str) -> list[tuple[str, str]]:
+    """Return list of (filename, full_url) for all BOD detail pages on the index."""
     soup = BeautifulSoup(html, "html.parser")
     seen: set[str] = set()
     links: list[tuple[str, str]] = []
@@ -76,12 +123,43 @@ def _parse_bod_links(html: str) -> list[tuple[str, str]]:
         if full_url in seen:
             continue
         seen.add(full_url)
-        # Derive filename from the URL slug, preserving the full slug for traceability
         slug = Path(path).name
         filename = sanitize_filename(slug) + ".html"
         links.append((filename, full_url))
 
     return links
+
+
+def _links_from_known_urls() -> list[tuple[str, str]]:
+    """Convert KNOWN_URLS to (filename, url) format."""
+    links = []
+    for url in KNOWN_URLS:
+        slug = Path(urlparse(url).path).name
+        filename = sanitize_filename(slug) + ".html"
+        links.append((filename, url))
+    return links
+
+
+def _try_scrape() -> Optional[list[tuple[str, str]]]:
+    """Try plain requests then Playwright to scrape the index. Returns links or None."""
+    html = _fetch_html_plain()
+    if html:
+        links = _parse_bod_links(html)
+        if links:
+            return links
+
+    html = _fetch_html_playwright()
+    if html:
+        links = _parse_bod_links(html)
+        if links:
+            return links
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 
 def run(
@@ -93,14 +171,13 @@ def run(
     dest = output_dir / "cisa-bod"
     result = DownloadResult(framework="cisa-bod")
 
-    html = _fetch_html(SOURCE_URL)
-    if html is None:
-        result.errors.append(("", f"Failed to fetch CISA directives index: {SOURCE_URL}"))
-        return result
+    links = _try_scrape()
+    used_known_urls = links is None
+    if links is None:
+        links = _links_from_known_urls()
 
-    links = _parse_bod_links(html)
     if not links:
-        result.errors.append(("", "No BOD pages found on CISA directives index"))
+        result.errors.append(("", f"Failed to fetch CISA directives index: {SOURCE_URL}"))
         return result
 
     if dry_run:
@@ -110,6 +187,12 @@ def run(
                 result.skipped.append(filename)
             else:
                 result.downloaded.append(filename)
+        if used_known_urls:
+            result.notices.append(
+                f"Automated index scrape unavailable — CISA WAF blocked access. "
+                f"Used last-known-good URL list (last verified {KNOWN_URLS_VERIFIED}). "
+                f"See cwm/downloaders/cisa_bod.py (KNOWN_URLS) for the full URL list."
+            )
         return result
 
     dest.mkdir(parents=True, exist_ok=True)
@@ -124,5 +207,12 @@ def run(
             result.downloaded.append(filename)
         else:
             result.errors.append((filename, msg))
+
+    if used_known_urls:
+        result.notices.append(
+            f"Automated index scrape unavailable — CISA WAF blocked access. "
+            f"Used last-known-good URL list (last verified {KNOWN_URLS_VERIFIED}). "
+            f"See cwm/downloaders/cisa_bod.py (KNOWN_URLS) for the full URL list."
+        )
 
     return result


### PR DESCRIPTION
## Problem

CISA's WAF blocks plain `requests.get()` on the directives index page, causing the downloader to error out immediately:

```
Syncing CISA Binding Operational Directives... done.
  Errors     : 1
    : Failed to fetch CISA directives index: https://www.cisa.gov/directives
```

## Fix

Applied the same three-tier strategy already used for CMMC:

1. **Plain requests** — fast path, works if WAF allows it
2. **Playwright headless browser** — fallback if plain request is blocked
3. **`KNOWN_URLS` curated list** — 17 BOD detail page URLs hardcoded as last resort (verified 2026-02-26)

When the fallback is triggered, a `[!]` notice is shown consistent with the CMMC pattern:

```
  [!] Automated index scrape unavailable — CISA WAF blocked access. Used
      last-known-good URL list (last verified 2026-02-26). See
      cwm/downloaders/cisa_bod.py (KNOWN_URLS) for the full URL list.
```

## Test plan

- [ ] Sync CISA BOD — confirm it completes (either via Playwright or KNOWN_URLS fallback)
- [ ] If fallback used, confirm `[!]` notice appears
- [ ] Re-sync — confirm files reported as up to date
- [ ] `ruff check cwm/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)