### PR TITLE
fix(downloaders): write _known-urls.txt when fallback is used

### DIFF
--- a/cwm/downloaders/cisa_bod.py
+++ b/cwm/downloaders/cisa_bod.py
@@ -140,6 +140,19 @@ def _links_from_known_urls() -> list[tuple[str, str]]:
     return links
 
 
+def _write_known_urls_file(dest: Path) -> None:
+    """Write a plain-text list of KNOWN_URLS to dest/_known-urls.txt."""
+    lines = [
+        f"# CISA BOD known fallback URLs — last verified {KNOWN_URLS_VERIFIED}",
+        "# Used when the CISA WAF blocks automated scraping of the directives index.",
+        f"# Source page: {SOURCE_URL}",
+        "",
+    ]
+    for url in KNOWN_URLS:
+        lines.append(url)
+    (dest / "_known-urls.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def _try_scrape() -> Optional[list[tuple[str, str]]]:
     """Try plain requests then Playwright to scrape the index. Returns links or None."""
     html = _fetch_html_plain()
@@ -191,11 +204,12 @@ def run(
             result.notices.append(
                 f"Automated index scrape unavailable — CISA WAF blocked access. "
                 f"Used last-known-good URL list (last verified {KNOWN_URLS_VERIFIED}). "
-                f"See cwm/downloaders/cisa_bod.py (KNOWN_URLS) for the full URL list."
+                f"See source-content/cisa-bod/_known-urls.txt for the full URL list."
             )
         return result
 
     dest.mkdir(parents=True, exist_ok=True)
+    _write_known_urls_file(dest)
     session = requests.Session()
 
     for filename, url in links:
@@ -212,7 +226,7 @@ def run(
         result.notices.append(
             f"Automated index scrape unavailable — CISA WAF blocked access. "
             f"Used last-known-good URL list (last verified {KNOWN_URLS_VERIFIED}). "
-            f"See cwm/downloaders/cisa_bod.py (KNOWN_URLS) for the full URL list."
+            f"See source-content/cisa-bod/_known-urls.txt for the full URL list."
         )
 
     return result

--- a/cwm/downloaders/cmmc.py
+++ b/cwm/downloaders/cmmc.py
@@ -181,6 +181,24 @@ def _links_from_known_urls() -> list[tuple[str, str, str]]:
 
 
 # ---------------------------------------------------------------------------
+# Known-URL file writer
+# ---------------------------------------------------------------------------
+
+
+def _write_known_urls_file(dest: Path) -> None:
+    """Write a plain-text list of KNOWN_URLS to dest/_known-urls.txt."""
+    lines = [
+        f"# CMMC known fallback URLs — last verified {KNOWN_URLS_VERIFIED}",
+        "# Used when the DoD portal blocks automated scraping of the resources page.",
+        f"# Source page: {SOURCE_URL}",
+        "",
+    ]
+    for _section, url in KNOWN_URLS:
+        lines.append(url)
+    (dest / "_known-urls.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
 # Downloading
 # ---------------------------------------------------------------------------
 
@@ -242,16 +260,17 @@ def run(
             result.notices.append(
                 f"Automated download unavailable — DoD portal blocked access. "
                 f"Used last-known-good URL list (last verified {KNOWN_URLS_VERIFIED}). "
-                f"See cwm/downloaders/cmmc.py (KNOWN_URLS) for the full URL list."
+                f"See source-content/cmmc/_known-urls.txt for the full URL list."
             )
         return result
 
     dest.mkdir(parents=True, exist_ok=True)
+    _write_known_urls_file(dest)
     result = _requests_download(links, dest, force, state)
     if used_known_urls:
         result.notices.append(
             f"Automated download unavailable — DoD portal blocked access. "
             f"Used last-known-good URL list (last verified {KNOWN_URLS_VERIFIED}). "
-            f"See cwm/downloaders/cmmc.py (KNOWN_URLS) for the full URL list."
+            f"See source-content/cmmc/_known-urls.txt for the full URL list."
         )
     return result


### PR DESCRIPTION
## Problem

When CMMC or CISA BOD fell back to `KNOWN_URLS`, the notice pointed users at Python source code (`cwm/downloaders/cmmc.py`) to find the URL list — not useful or discoverable.

## Fix

When the fallback is triggered, a plain-text `_known-urls.txt` file is written directly into the download directory:

- `source-content/cmmc/_known-urls.txt`
- `source-content/cisa-bod/_known-urls.txt`

**File contents (CMMC example):**
```
# CMMC known fallback URLs — last verified 2026-02-25
# Used when the DoD portal blocks automated scraping of the resources page.
# Source page: https://dodcio.defense.gov/cmmc/Resources-Documentation/

https://dowcio.war.gov/Portals/0/Documents/CMMC/CMMC-FAQsv4.pdf
https://dodcio.defense.gov/Portals/0/Documents/CMMC/CMMC-101-Nov2025.pdf
...
```

Notice updated to reference the file:
```
[!] Automated download unavailable — DoD portal blocked access. Used last-known-good
    URL list (last verified 2026-02-25). See source-content/cmmc/_known-urls.txt
    for the full URL list.
```

## Test plan

- [ ] Sync CMMC with fallback active — confirm `source-content/cmmc/_known-urls.txt` is created
- [ ] Sync CISA BOD with fallback active — confirm `source-content/cisa-bod/_known-urls.txt` is created
- [ ] Verify file contents are plain text with one URL per line
- [ ] `ruff check cwm/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)