### PR TITLE
feat(cli): acquisition-mode split in framework sub-menus

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -166,7 +166,7 @@ def _print_framework_menu(group: str, svcs: list, entries: dict, state) -> None:
     for i, svc in enumerate(svcs, 1):
         if has_non_auto and not in_manual_section and svc.acquisition != "auto":
             print()
-            label = "── Manual Acquisition "
+            label = "── Partial / Manual Acquisition "
             print(f"  {label}{'─' * (WIDTH - 2 - len(label))}")
             in_manual_section = True
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -75,11 +75,22 @@ def _print_section(title: str) -> None:
 
 
 def _status_icon(entries: dict, svc) -> str:
-    """Return a status icon for a service based on its sync state."""
+    """Return a status icon for a service based on acquisition mode and sync state."""
+    if svc.acquisition == "manual":
+        return "[M]"
+    if svc.acquisition == "mixed":
+        return "[~]"
     prefix = svc.subdir + "/"
     if any(k.startswith(prefix) for k in entries):
         return "[x]"
     return "[ ]"
+
+
+def _split_by_acquisition(svcs: list) -> list:
+    """Return services ordered: auto first (preserving order), then mixed/manual."""
+    auto = [s for s in svcs if s.acquisition == "auto"]
+    non_auto = [s for s in svcs if s.acquisition != "auto"]
+    return auto + non_auto
 
 
 # ---------------------------------------------------------------------------
@@ -143,15 +154,29 @@ def _print_group_menu(groups: list[str], services_by_group: dict, entries: dict)
 
 
 def _print_framework_menu(group: str, svcs: list, entries: dict, state) -> None:
+    """Print the framework sub-menu. svcs must be pre-ordered (auto first, then mixed/manual)."""
     print()
     print(_BAR)
     print(group)
     print(_BAR)
+
+    has_non_auto = any(s.acquisition != "auto" for s in svcs)
+    in_manual_section = False
+
     for i, svc in enumerate(svcs, 1):
+        if has_non_auto and not in_manual_section and svc.acquisition != "auto":
+            print()
+            label = "── Manual Acquisition "
+            print(f"  {label}{'─' * (WIDTH - 2 - len(label))}")
+            in_manual_section = True
+
         icon = _status_icon(entries, svc)
         info = _svc_info(svc, entries, state)
         print(f"  {icon} [{i}]  {svc.label:<36} {info}")
+
     print()
+    print(_BAR)
+    print("  [x] synced  [ ] not synced  [~] partial  [M] manual only")
     print(_BAR)
     print("  s = sync all  |  n = normalize  |  b = back  |  x = main menu  |  q = quit")
     print(_BAR)
@@ -367,7 +392,7 @@ def main() -> None:
 
         elif choice.isdigit() and 1 <= int(choice) <= len(active_groups):
             group = active_groups[int(choice) - 1]
-            svcs  = active_by_group[group]
+            svcs  = _split_by_acquisition(active_by_group[group])
 
             while True:
                 _print_framework_menu(group, svcs, state.entries(), state)

--- a/core/cli.py
+++ b/core/cli.py
@@ -219,7 +219,7 @@ def _run_sync(svc, output_dir: Path, state):
             for notice in result.notices:
                 print(f"      [!] {notice}")
 
-        total = downloaded + skipped + errors
+        total = downloaded + skipped + errors + manual
         if total > 0:
             state.set_service_total(svc.key, total)
         return result

--- a/core/downloaders/__init__.py
+++ b/core/downloaders/__init__.py
@@ -56,8 +56,9 @@ class ServiceDef:
     key: str
     label: str
     runner: Callable[[Path, bool, bool, Optional["StateFile"]], DownloadResult]
-    subdir: str  # path prefix under output_dir used by this downloader
-    group: str   # top-level menu group this service belongs to
+    subdir: str         # path prefix under output_dir used by this downloader
+    group: str          # top-level menu group this service belongs to
+    acquisition: str = "auto"  # "auto" | "mixed" | "manual"
 
 
 # Ordered display groups for the top-level menu.
@@ -109,13 +110,16 @@ SERVICES: list[ServiceDef] = [
         cisa_kev.run, "cisa-kev", "CISA",
     ),
     # ── DoD / Defense ─────────────────────────────────────────────────────────
-    ServiceDef("cmmc", "CMMC", cmmc.run, "cmmc", "DoD / Defense"),
+    ServiceDef("cmmc", "CMMC", cmmc.run, "cmmc", "DoD / Defense", acquisition="mixed"),
     ServiceDef("disa", "DISA STIGs", disa.run, "disa-stigs", "DoD / Defense"),
     ServiceDef(
         "dfars-far", "DFARS / FAR Cybersecurity Clauses",
         dfars_far.run, "dfars-far", "DoD / Defense",
     ),
-    ServiceDef("dod-zt", "DoD Zero Trust & Directives", dod_zt.run, "dod-zt", "DoD / Defense"),
+    ServiceDef(
+        "dod-zt", "DoD Zero Trust & Directives",
+        dod_zt.run, "dod-zt", "DoD / Defense", acquisition="mixed",
+    ),
     ServiceDef(
         "dod-devsecops", "DoD DevSecOps & cATO",
         dod_devsecops.run, "dod-devsecops", "DoD / Defense",
@@ -129,10 +133,13 @@ SERVICES: list[ServiceDef] = [
         "dod-cloud", "DoD Cloud Security",
         dod_cloud.run, "dod-cloud", "DoD / Defense",
     ),
-    ServiceDef("nsa", "NSA Cybersecurity Advisories", nsa.run, "nsa", "DoD / Defense"),
+    ServiceDef(
+        "nsa", "NSA Cybersecurity Advisories",
+        nsa.run, "nsa", "DoD / Defense", acquisition="manual",
+    ),
     ServiceDef(
         "nispom", "DCSA NISPOM (32 CFR Part 117)",
-        nispom.run, "nispom", "DoD / Defense",
+        nispom.run, "nispom", "DoD / Defense", acquisition="mixed",
     ),
     ServiceDef("cnss", "CNSS Instructions & Policies", cnss.run, "cnss", "DoD / Defense"),
     # ── Threat Intel ──────────────────────────────────────────────────────────
@@ -147,7 +154,10 @@ SERVICES: list[ServiceDef] = [
         "cis-controls", "CIS Controls v8 (Structured Data)",
         cis_controls.run, "cis-controls", "Frameworks",
     ),
-    ServiceDef("pci-dss", "PCI DSS v4.0.1", pci_dss.run, "pci-dss", "Frameworks"),
+    ServiceDef(
+        "pci-dss", "PCI DSS v4.0.1",
+        pci_dss.run, "pci-dss", "Frameworks", acquisition="mixed",
+    ),
     ServiceDef("soc2", "SOC 2 / AICPA Trust Services Criteria", soc2.run, "soc2", "Frameworks"),
     ServiceDef(
         "cis-benchmarks", "CIS Benchmarks",
@@ -168,11 +178,11 @@ SERVICES: list[ServiceDef] = [
     # ── International Standards ───────────────────────────────────────────────
     ServiceDef(
         "iso27k", "ISO/IEC 27000 Series",
-        iso27k.run, "iso27k", "International Standards",
+        iso27k.run, "iso27k", "International Standards", acquisition="manual",
     ),
     ServiceDef(
         "iec62443", "IEC 62443 (IACS Security)",
-        iec62443.run, "iec62443", "International Standards",
+        iec62443.run, "iec62443", "International Standards", acquisition="manual",
     ),
     ServiceDef(
         "common-criteria", "Common Criteria (ISO/IEC 15408)",


### PR DESCRIPTION
## Summary

- Adds `acquisition` field to `ServiceDef` (`"auto"` | `"mixed"` | `"manual"`) as the registry-level source of truth for each framework's download capability
- Rebuilds framework sub-menus to split automated entries from partial/manual ones under a `── Partial / Manual Acquisition` section divider (only shown when the group has non-auto entries)
- New status icons: `[x]` synced · `[ ]` not synced · `[~]` partial · `[M]` manual only — with a legend line printed above the action bar
- Fixes service total count to include `manual_required` items so mixed frameworks show an accurate ratio (e.g. `2/20` instead of `2/2`)

**Tagged across 38 frameworks:** 31 auto · 4 mixed (CMMC, DoD ZT, NISPOM, PCI DSS) · 3 manual (NSA, ISO/IEC 27000, IEC 62443)

## Test plan

- [ ] Pull branch and launch tool (`python3 compligator.py`)
- [ ] Open DoD / Defense — confirm auto entries above divider, CMMC/DoD ZT/NISPOM as `[~]`, NSA as `[M]`
- [ ] Open International Standards — confirm CC + GDPR above divider, ISO/IEC + IEC 62443 as `[M]`
- [ ] Open a pure-auto group (NIST, CISA) — confirm no divider appears
- [ ] Sync a mixed framework — confirm denominator updates to include manual doc count
- [ ] Select a `[M]` or `[~]` item by number — confirm sync runs and surfaces `manual_required` output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)